### PR TITLE
fix: Set the item as unavailable on creation.

### DIFF
--- a/backend/src/businessLogic/itemService.ts
+++ b/backend/src/businessLogic/itemService.ts
@@ -34,7 +34,7 @@ export async function createItem(
         userId: userId,
         itemId: itemId,
         createdAt: new Date().toISOString(),
-        isAvailable: true,
+        isAvailable: false,
         attachmentUrl: image_placeholder_url,
         categoryStatus: requestItem.category,
         ...requestItem


### PR DESCRIPTION
An item created by user will not be published after it is created. This
is to give control to the user to publish the item only if he/she feels
the details are complete.